### PR TITLE
infinite loop bug

### DIFF
--- a/jquery-loadTemplate/jquery.loadTemplate-1.2.1.js
+++ b/jquery-loadTemplate/jquery.loadTemplate-1.2.1.js
@@ -36,9 +36,11 @@
             return processArray.call(this, template, data, settings);
         }
 
-        if (!containsSlashes(template) || template.indexOf('#') === 0) {
+        if (!containsSlashes(template)) {
             $template = $(template);
-            settings.isFile = false;
+            if (typeof template === 'string' && template.indexOf('#') === 0) {
+                settings.isFile = false;
+            }
         }
 
         isFile = settings.isFile || (typeof settings.isFile === "undefined" && (typeof $template === "undefined" || $template.length === 0));


### PR DESCRIPTION
If a template selector passed to loadTemplate function and no element
found for that selector the script will go in an infinite loop so we
need to exit if there is no template element
